### PR TITLE
1.1 exe binary + warning

### DIFF
--- a/LEB-ToolBox.py
+++ b/LEB-ToolBox.py
@@ -43,10 +43,10 @@ def colorize(string):
 
     
 ####### PROGRAM VERSION #######
-cnt_program = 1.0
+cnt_program = 1.1
 ver_program = G+"v"+str(cnt_program)+W
 
-ver_info = "$OLEB-ToolBox v1.0 changelog:\n$W-$G NEW $Wconfiguration file upgrader; no more settings lost when updating the program.\n$W-$G NEW$W Legacy Resetter option is now avilable. Read the documentation or make a new server install to know more.\n$W-$G NEW $WDependecies required.\n$W-$G NEW $WNow every update displays the changelog when launching for the first time, or before updating to a new version.\n$W-$G NEW $WWelcome message.\n$W-$G NEW $WSee Changelog option in Main Menu.\n$W"
+ver_info = "$OLEB-ToolBox v1.1 changelog:\n$W-$G NEW $WTake All dependecy and R26 compatibility.$W"
 ####### PROGRAM VERSION #######
 
 repo = "DBTDerpbox"

--- a/LEB-ToolBox.py
+++ b/LEB-ToolBox.py
@@ -43,11 +43,10 @@ def colorize(string):
 
     
 ####### PROGRAM VERSION #######
-cnt_program = 1.0.1
-
+cnt_program = 1.0
 ver_program = G+"v"+str(cnt_program)+W
 
-ver_info = "$OLEB-ToolBox v1.0.1 changelog:\n$W-$G NEW $Wdependencies added. You must perform an update.$W"
+ver_info = "$OLEB-ToolBox v1.0 changelog:\n$W-$G NEW $Wconfiguration file upgrader; no more settings lost when updating the program.\n$W-$G NEW$W Legacy Resetter option is now avilable. Read the documentation or make a new server install to know more.\n$W-$G NEW $WDependecies required.\n$W-$G NEW $WNow every update displays the changelog when launching for the first time, or before updating to a new version.\n$W-$G NEW $WWelcome message.\n$W-$G NEW $WSee Changelog option in Main Menu.\n$W"
 ####### PROGRAM VERSION #######
 
 repo = "DBTDerpbox"
@@ -1584,7 +1583,9 @@ def checkForUpdates():
         info = data.split("\n")
         for line in info:
             if "cnt_program = " in line:
-                ver1 = float(line.split("cnt_program = ")[1])
+                value = line.split("cnt_program = ")[1]
+                value = value.replace("\r","")
+                ver1 = float(value)
                 if ver1 > cnt_program:
                     global online_count_program
                     online_count_program = ver1
@@ -1592,6 +1593,8 @@ def checkForUpdates():
                 else:
                     return 0
     except Exception as error:
+        print(str(error))
+        input()
         return -1
     
 def checkForChangeLog():
@@ -1601,7 +1604,9 @@ def checkForChangeLog():
         info = data.split("\n")
         for line in info:
             if "ver_info = " in line:
-                changelog = line.split("ver_info = ")[1]
+                value = line.split("ver_info = ")[1]
+                value = value.replace("\r","")
+                changelog = value
                 return colorize(str(changelog))
             
     except Exception as error:

--- a/LEB-ToolBox.py
+++ b/LEB-ToolBox.py
@@ -44,6 +44,7 @@ def colorize(string):
     
 ####### PROGRAM VERSION #######
 cnt_program = 1.0.1
+
 ver_program = G+"v"+str(cnt_program)+W
 
 ver_info = "$OLEB-ToolBox v1.0.1 changelog:\n$W-$G NEW $Wdependencies added. You must perform an update.$W"

--- a/LEB-ToolBox.py
+++ b/LEB-ToolBox.py
@@ -43,10 +43,10 @@ def colorize(string):
 
     
 ####### PROGRAM VERSION #######
-cnt_program = 1.0
+cnt_program = 1.0.1
 ver_program = G+"v"+str(cnt_program)+W
 
-ver_info = "$OLEB-ToolBox v1.0 changelog:\n$W-$G NEW $Wconfiguration file upgrader; no more settings lost when updating the program.\n$W-$G NEW$W Legacy Resetter option is now avilable. Read the documentation or make a new server install to know more.\n$W-$G NEW $WDependecies required.\n$W-$G NEW $WNow every update displays the changelog when launching for the first time, or before updating to a new version.\n$W-$G NEW $WWelcome message.\n$W-$G NEW $WSee Changelog option in Main Menu.\n$W"
+ver_info = "$OLEB-ToolBox v1.0.1 changelog:\n$W-$G NEW $Wdependencies added. You must perform an update.$W"
 ####### PROGRAM VERSION #######
 
 repo = "DBTDerpbox"


### PR DESCRIPTION
1.1 binaries exe uploaded
1.1 is now live (autoupdater will now tell users to update)

two important things to note:
- your linux build is probably labeled as "1.0". This will efectively make your version of the program update itself forever until you add a new compiled version of the program with the "1.1" version label. (the py file has already been edited to include this.)
- for now on, every update you want to push to the end users will require you to change the version number to something higher than the number found on the py version configuration parameter. You must only input decimal numbers: that means that 1.0.1 for example won't work ---> use instead 1.1, 1.2,...

no direct push to repo, so another PR coming on the way.