### PR TITLE
Add arguments for the command line installation of servers.

### DIFF
--- a/src/main/java/net/kyrptonaught/ToolBox/Automation.java
+++ b/src/main/java/net/kyrptonaught/ToolBox/Automation.java
@@ -1,8 +1,20 @@
 package net.kyrptonaught.ToolBox;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+
+import net.kyrptonaught.ToolBox.Menu.State;
+import net.kyrptonaught.ToolBox.IO.ConfigLoader;
+import net.kyrptonaught.ToolBox.IO.EulaChecker;
+import net.kyrptonaught.ToolBox.IO.FileHelper;
+import net.kyrptonaught.ToolBox.IO.GithubHelper;
+import net.kyrptonaught.ToolBox.configs.BranchConfig;
+import net.kyrptonaught.ToolBox.configs.BranchesConfig;
 import net.kyrptonaught.ToolBox.holders.InstalledServerInfo;
 
 public class Automation {
+    static BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
 
     public static void run() {
         String serverName = CMDArgsParser.getTargetServer();
@@ -16,5 +28,48 @@ public class Automation {
 
         if (CMDArgsParser.launchServer())
             Executer.startServer(server);
+        
+        if (CMDArgsParser.installServer()) {
+            BranchesConfig.BranchInfo branchInfo = CMDArgsParser.getNewServerBranch();
+
+            String url = GithubHelper.convertRepoToToolboxConfig(branchInfo.url);
+            BranchConfig branch = ConfigLoader.parseToolboxConfig(FileHelper.download(url));
+
+            if (branch == null) {
+                System.out.println();
+                System.out.println("This branch is invalid.");
+                System.out.println("Returning to menu.");
+                Menu.pressEnterToCont(input);
+
+                return;
+            }
+
+            String name = CMDArgsParser.getTargetServer();
+
+            int allocatedRam = CMDArgsParser.getNewServerRam();
+
+            InstalledServerInfo serverInfo = new InstalledServerInfo(branch, branchInfo);
+            serverInfo.setName(name);
+            serverInfo.setPath();
+            if (allocatedRam < 1) allocatedRam = 3;
+            serverInfo.setCustomLaunchArgs("-Xmx" + allocatedRam + "G -Xms" + allocatedRam + "G");
+
+            Installer.installAndCheckForUpdates(serverInfo);
+            if (CMDArgsParser.doesNewServerAgreeToEULA()) {
+                Path eulaFile = serverInfo.getPath().resolve("eula.txt");
+
+                EulaChecker.agreeToEula(eulaFile);
+            } else if (!CMDArgsParser.unattendedInstall()) {
+                Menu.checkEula(input, serverInfo);
+            } else System.out.println("Did not agree to Mojang's EULA");
+
+            if (CMDArgsParser.unattendedInstall()) {
+                Menu.setState(State.EXIT);
+            } else {
+                Menu.pressEnterToCont(input);
+
+                Menu.setState(State.EXISTING_INSTALL, serverInfo);
+            }
+        }
     }
 }

--- a/src/main/java/net/kyrptonaught/ToolBox/CMDArgsParser.java
+++ b/src/main/java/net/kyrptonaught/ToolBox/CMDArgsParser.java
@@ -1,5 +1,9 @@
 package net.kyrptonaught.ToolBox;
 
+import net.kyrptonaught.ToolBox.IO.ConfigLoader;
+import net.kyrptonaught.ToolBox.IO.FileHelper;
+import net.kyrptonaught.ToolBox.configs.BranchConfig;
+import net.kyrptonaught.ToolBox.configs.BranchesConfig;
 
 public class CMDArgsParser {
 
@@ -58,5 +62,52 @@ public class CMDArgsParser {
 
     public static boolean updateAll() {
         return containsArgs("--updateAll");
+    }
+
+    public static boolean installServer() {
+        return containsArgs("--installServer");
+    }
+
+    public static int getNewServerRam() {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (args[i].equalsIgnoreCase("--newServerRam") && !args[i + 1].startsWith("--")) {
+                return Integer.parseInt(args[i + 1]);
+            }
+        }
+        return 3;
+    }
+
+    public static BranchesConfig.BranchInfo getNewServerBranch() {
+        BranchesConfig availableBranches = ConfigLoader.parseBranches(FileHelper.download("https://raw.githubusercontent.com/Legacy-Edition-Minigames/ToolBox/java/testConfigs/TestBranches.json"));
+
+        for (int i = 0; i < args.length - 1; i++) {
+            if (args[i].equalsIgnoreCase("--newServerBranch") && !args[i + 1].startsWith("--")) {
+                String branchURL = args[i + 1];
+                
+                for (BranchesConfig.BranchInfo branch : availableBranches.branches) {
+                    if (branchURL == branch.url) {
+                        return branch;
+                    }
+                }
+            }
+        }
+        System.out.println("Using default branch");
+
+        BranchesConfig.BranchInfo defaultBranch = availableBranches.branches.get(0);
+
+        return defaultBranch;
+    }
+
+    public static boolean doesNewServerAgreeToEULA() {
+        for (int i = 0; i < args.length - 1; i++) {
+            if (args[i].equalsIgnoreCase("--newServerEULA") && !args[i + 1].startsWith("--")) {
+                return Boolean.parseBoolean(args[i+1]);
+            }
+        }
+        return false;
+    }
+
+    public static boolean unattendedInstall() {
+        return containsArgs("--unattendedInstall");
     }
 }

--- a/src/main/java/net/kyrptonaught/ToolBox/CMDArgsParser.java
+++ b/src/main/java/net/kyrptonaught/ToolBox/CMDArgsParser.java
@@ -85,7 +85,7 @@ public class CMDArgsParser {
                 String branchURL = args[i + 1];
                 
                 for (BranchesConfig.BranchInfo branch : availableBranches.branches) {
-                    if (branchURL == branch.url) {
+                    if (branchURL.equals(branch.url)) {
                         return branch;
                     }
                 }


### PR DESCRIPTION
The changes add support for the following command line arguments:

`--installServer`: Installs a new server with the name specified with `--server`.

`--newServerRam`: The RAM to be allocated to the newly installed server in GB, defaults to 3.

`--newServerBranch`: The branch to install the server from, defaults to https://github.com/Legacy-Edition-Minigames/Minigames/tree/toolbox-testing.

`--newServerEULA`: Agree to Mojang's EULA from the command line, takes true or false as an argument.

`--unattendedInstall`: If specified sane defaults will be chosen for all input required, currently it only makes EULA acceptance default to false, additionally it will cause the GUI to close immediately after installation. This allows for unattended installation but is also useful for installation via external programs.

This is my first pull request so feedback would be appreciated,
Merry Christmas.