### PR TITLE
Fixed weird behaviour when the installer jar's IO was inherited from the main program

### DIFF
--- a/src/main/java/net/kyrptonaught/ToolBox/UpdateChecker.java
+++ b/src/main/java/net/kyrptonaught/ToolBox/UpdateChecker.java
@@ -45,10 +45,10 @@ public class UpdateChecker {
                 FileHelper.download(obj.get("browser_download_url").getAsString(), Paths.get(".toolbox").resolve("update").resolve(obj.get("name").getAsString()));
             }
 
-            FileHelper.copyFile(Paths.get(".").resolve("ToolBox2.0.jar"), Paths.get(".toolbox").resolve("Updater.jar"));
+            FileHelper.copyFile(Paths.get(".").resolve("Toolbox2.0.jar"), Paths.get(".toolbox").resolve("Updater.jar"));
             FileHelper.writeFile(Paths.get(".toolbox").resolve("UPDATE_IN_PROGRESS"), "rua");
 
-            launchJar(".toolbox/Updater.jar", "--updater");
+            launchJar(".toolbox/Updater.jar", "--updater", true);
         }
     }
 
@@ -81,17 +81,23 @@ public class UpdateChecker {
         BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
         Menu.pressEnterToCont(input);
 
-        launchJar("Toolbox2.0.jar", "");
+        launchJar("Toolbox2.0.jar", "", true);
     }
 
-    private static void launchJar(String jar, String args) {
+    private static void launchJar(String jar, String args, Boolean waitfor) {
         try {
-            new ProcessBuilder("java", "-jar", jar, args)
+            ProcessBuilder launcher = new ProcessBuilder("java", "-jar", jar, args)
                     .directory(new File(System.getProperty("user.dir")))
-                    .inheritIO()
-                    .start();
+                    .inheritIO();
+
+            Process launchedjar = launcher.start();
 
             Menu.SKIP_SHUTDOWN_TASKS = true;
+
+            if (waitfor) {
+                launchedjar.waitFor();
+            }
+
             System.exit(0);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
The `launchjar()` function now has a `waitfor` parameter, when true the `launchjar()` function will wait for the new process to exit before it exits itself, this stops the terminal from thinking the process has ended. Additionally, I fixed an error where the self-updater assumed the toolbox jar had a capital B and couldn't find the file.