### PR TITLE
Include ToolBox Icon in ToolBox Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LEM ToolBox
+# ![LEM Toolbox](https://github.com/user-attachments/assets/ac63610e-e2d3-4309-bed7-3f2f7d450bac) LEM ToolBox
 
 [![forthebadge](https://forthebadge.com/images/badges/made-with-java.svg)](https://forthebadge.com)
 


### PR DESCRIPTION
Includes ToolBox icon in ReadMe
<img width="80" height="80" alt="Toolbox" src="https://github.com/user-attachments/assets/b9f8b06e-4256-4b71-af54-8386a5cef85e" />
